### PR TITLE
Add support for "args" tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,8 +285,7 @@ Given a regular expression string value, asserts that the program output
 
 ### `"args"` tag
 
-Given either a string array or string value, run the program with the value as
-command line arguments.  String values are split on `" "` (space).
+Given a string array, run the program with the value as command line arguments.
 
 ### `"interrupt"` tag
 

--- a/README.md
+++ b/README.md
@@ -283,6 +283,11 @@ package lolmain
 Given a regular expression string value, asserts that the program output
 (stdout) matches.
 
+### `"args"` tag
+
+Given either a string array or string value, run the program with the value as
+command line arguments.  String values are split on `" "` (space).
+
 ### `"interrupt"` tag
 
 Given either a truthy or duration string value, interrupts the program via

--- a/runnable.go
+++ b/runnable.go
@@ -103,9 +103,15 @@ func (rn *Runnable) Args() []string {
 	rn.parseTags()
 
 	if v, ok := rn.Tags["args"]; ok {
-		if slv, ok := v.([]string); ok {
+		if iv, ok := v.([]interface{}); ok {
+			slv := []string{}
+			for _, v := range iv {
+				slv = append(slv, v.(string))
+			}
 			return slv
 		}
+
+		fmt.Fprintf(os.Stderr, "---> unknown \"args\" type %T value=%#v\n", v, v)
 	}
 
 	return nil
@@ -133,9 +139,9 @@ func (rn *Runnable) IsValidOS() bool {
 	switch v.(type) {
 	case string:
 		return runtime.GOOS == v.(string)
-	case []string:
-		for _, s := range v.([]string) {
-			if runtime.GOOS == s {
+	case []interface{}:
+		for _, s := range v.([]interface{}) {
+			if runtime.GOOS == s.(string) {
 				return true
 			}
 		}

--- a/runnable.go
+++ b/runnable.go
@@ -101,11 +101,8 @@ func (rn *Runnable) Interruptable() (bool, time.Duration) {
 
 func (rn *Runnable) Args() []string {
 	rn.parseTags()
-	if v, ok := rn.Tags["args"]; ok {
-		if sv, ok := v.(string); ok {
-			return strings.Split(sv, " ")
-		}
 
+	if v, ok := rn.Tags["args"]; ok {
 		if slv, ok := v.([]string); ok {
 			return slv
 		}

--- a/runnable.go
+++ b/runnable.go
@@ -110,8 +110,6 @@ func (rn *Runnable) Args() []string {
 			}
 			return slv
 		}
-
-		fmt.Fprintf(os.Stderr, "---> unknown \"args\" type %T value=%#v\n", v, v)
 	}
 
 	return nil


### PR DESCRIPTION
including html unescaping of raw tags string so that &#45;&#45;long&#45;opts (`&#45;&#45;long&#45;opts`) can appear within markdown comments.
