### PR TITLE
Properly catch and display error on pull command

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -241,11 +241,9 @@ func cliDumpLanguages(ctx *cli.Context) error {
 }
 
 func cliPullLanguages(ctx *cli.Context) error {
-	log := logrus.New()
 	err := PullLanguagesYml(ctx.String("languages-url"), ctx.String("languages"))
 	if err != nil {
-		log.Error(err)
-		return cli.Exit("", 2)
+		return cli.Exit(err.Error(), 2)
 	}
 	return nil
 }

--- a/cli.go
+++ b/cli.go
@@ -241,7 +241,13 @@ func cliDumpLanguages(ctx *cli.Context) error {
 }
 
 func cliPullLanguages(ctx *cli.Context) error {
-	return PullLanguagesYml(ctx.String("languages-url"), ctx.String("languages"))
+	log := logrus.New()
+	err := PullLanguagesYml(ctx.String("languages-url"), ctx.String("languages"))
+	if err != nil {
+		log.Error(err)
+		return cli.Exit("", 2)
+	}
+	return nil
 }
 
 func cliExtract(ctx *cli.Context) error {


### PR DESCRIPTION
Previously an error when calling `gfmrun pull-languages` wouldn't be
caught, and the CLI would exit `0` without an error message.

Brings up current issue of (No idea why unfortunately):

```
% gfmrun pull-languages
ERRO[0000] rename /tmp/gfmrun-linguist083437199
/home/jake/.cache/gfmrun/languages.yml: invalid cross-device link
```
