### PR TITLE
Add support for Go Modules

### DIFF
--- a/runnable.go
+++ b/runnable.go
@@ -240,6 +240,28 @@ func (rn *Runnable) Run(i int) *runResult {
 
 	nameBase := strings.Replace(tmpFile.Name(), "."+rn.Frob.Extension(), "", 1)
 
+	// look out for go files
+	if rn.Frob.Extension() == "go" {
+		// check if GO111MODULE env variable is set
+		if go111module := os.Getenv("GO111MODULE"); go111module != "" {
+			// if GO111MODULE is set and is not set to auto, proceed with create go module
+			if go111module != "auto" {
+				modFile, err := os.Create(filepath.Join(tmpDir, "go.mod"))
+				if err != nil {
+					return &runResult{Runnable: rn, Retcode: -1, Error: err}
+				}
+
+				if _, err := modFile.Write([]byte(fmt.Sprintf("module example%d", rn.LineOffset))); err != nil {
+					return &runResult{Runnable: rn, Retcode: -1, Error: err}
+				}
+
+				if err := modFile.Close(); err != nil {
+					return &runResult{Runnable: rn, Retcode: -1, Error: err}
+				}
+			}
+		}
+	}
+
 	expandedCommands := []*command{}
 
 	tmplVars := map[string]string{


### PR DESCRIPTION
With the introduction of Go Modules from Go 1.11+ I have noticed an error that occurs when we run gfmrun.

Usually, gfmrun creates a folder in tmp puts the code inside that folder and runs it. With go modules enabled if a go.mod file is not present, it is not possible for the dependencies to be downloaded and the code to be run.

This PR fixes it. Now gfmrun will first check if go modules are enabled. if enabled, it will also create a compatible go.mod file to make go modules work and the code to run. 