### PR TITLE
Add arm64 builds for linux and darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,16 @@ build: deps
 		-o gfmrun-linux-amd64-$(VERSION_VALUE) \
 		-ldflags "$(GOBUILD_LDFLAGS)" \
 		./cmd/gfmrun/main.go && \
+	GOOS=linux GOARCH=arm64 $(GO) build \
+		-o gfmrun-linux-arm64-$(VERSION_VALUE) \
+		-ldflags "$(GOBUILD_LDFLAGS)" \
+		./cmd/gfmrun/main.go && \
 	GOOS=darwin GOARCH=amd64 $(GO) build \
 		-o gfmrun-darwin-amd64-$(VERSION_VALUE) \
+		-ldflags "$(GOBUILD_LDFLAGS)" \
+		./cmd/gfmrun/main.go && \
+	GOOS=darwin GOARCH=arm64 $(GO) build \
+		-o gfmrun-darwin-arm64-$(VERSION_VALUE) \
 		-ldflags "$(GOBUILD_LDFLAGS)" \
 		./cmd/gfmrun/main.go && \
 	GOOS=windows GOARCH=amd64 $(GO) build \

--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ import (
   "fmt"
   "os"
 
-  "golang.org/x/example/stringutil"
+  "golang.org/x/example/hello/reverse"
 )
 
 func main() {
   fmt.Printf("---> %v\n", os.Args[0])
   fmt.Println("we could make an entire album out of this one sound")
-  fmt.Println(stringutil.Reverse("[SQUEAK INTENSIFIES]"))
+  fmt.Println(reverse.String("[SQUEAK INTENSIFIES]"))
 }
 ```
 


### PR DESCRIPTION
### Use case

I tried to run `make ensure-gfmrun` while working on `urfave/cli` on my Apple Silicon Mac but encountered this:

```
$ make ensure-gfmrun
go run scripts/build.go  ensure-gfmrun
# ---> /opt/homebrew/bin/git rev-parse --show-toplevel
# ---> /Users/Bartek.Pacia/projects/cli/.local/bin/gfmrun --version
2024/11/02 22:16:20 download file from https://github.com/urfave/gfmrun/releases/download/v1.3.0/gfmrun-darwin-arm64-v1.3.0 into /Users/Bartek.Pacia/projects/cli/.local/bin/gfmrun: response 404
exit status 1
make: *** [ensure-gfmrun] Error
```